### PR TITLE
update

### DIFF
--- a/procsdata.txt
+++ b/procsdata.txt
@@ -1,2 +1,2 @@
-java 1920x1080
-gedit 1920x1080
+java 1920x1080 1
+gedit 1920x1080 1


### PR DESCRIPTION
Rewritten to solve #4 and #5 .

Solves issue where applications that don't have a visible PID through `xdotools` can't be identified; queries for the process name, then uses `ps` to find the PID (try [blender](https://www.blender.org/download/) for an example).

Added cursor resize function, using `gesttings`, but it's not working on Ubuntu GNOME due to cursor theme issues on this platform; should work in Unity, requires testing.

Reduced the `time.sleep()` period.
